### PR TITLE
Generate documentation for all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ version = "2.3"
 optional = true
 features = ["xlib"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 xlib_xcb = ["x11/xlib"]
 thread = []


### PR DESCRIPTION
Currently, the documentation on docs.rs is generated only for the default features, meaning it barely contains any XCB modules.

docs.rs has [an option to generate documentation for all features](https://docs.rs/about). This pull request enables it. docs.rs should pick it up with the next release of the crate, and then it won't be necessary to host the documentation separately on http://rtbo.github.io/rust-xcb/xcb/index.html